### PR TITLE
feat(fix): update dependencies in useEffect for search input

### DIFF
--- a/src/components/HeadlessSearchInput.tsx
+++ b/src/components/HeadlessSearchInput.tsx
@@ -174,6 +174,7 @@ const HeadlessSearchInput = <T = Record<string, unknown>>({
         clearTimeout(debounceRef.current)
       }
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query, debounceMs, minQueryLength, performSearch])
 
   // Handle input change

--- a/src/components/HeadlessSearchInput.tsx
+++ b/src/components/HeadlessSearchInput.tsx
@@ -174,7 +174,7 @@ const HeadlessSearchInput = <T = Record<string, unknown>>({
         clearTimeout(debounceRef.current)
       }
     }
-  }, [query, debounceMs, minQueryLength, performSearch, results])
+  }, [query, debounceMs, minQueryLength, performSearch])
 
   // Handle input change
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## 📝 Description

Removed 'results' from dependency array in useEffect. This was causing the search to keep searching on headless input as results in acheived after debounce triggering a change to result forcing a rerun.

## 🧪 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)